### PR TITLE
ci: fix Gradle dependency submission (pin Gradle 8.13)

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,64 @@
+# Gradle Dependency Submission
+#
+# Generates the Gradle dependency graph (direct + transitive) and submits it
+# to GitHub's Dependency Graph API so Dependabot can see every dependency and
+# raise / resolve security alerts against the right versions.
+#
+# WHY THIS WORKFLOW EXISTS
+# ------------------------
+# It replaces GitHub's managed "Automatic Dependency Submission" feature,
+# which runs with the latest Gradle (9.6.0 at time of writing). Gradle 9.6.0
+# removed the internal `InternalProblems` API that Android Gradle Plugin
+# 8.13.2 relies on, so the managed run fails while applying the
+# `com.android.application` plugin with:
+#
+#   > Could not create service of type InternalProblems using
+#     ProblemsBuildTreeServices.createInternalProblems().
+#
+# (Gradle's own message recommends "use Gradle 9.5".) Pinning gradle-version
+# to 8.13 — the version this repo's wrapper targets and the one AGP 8.13.2
+# actually builds with — fixes the build.
+#
+# ACTION REQUIRED (one-time, in the GitHub UI):
+#   Settings -> Code security -> "Automatic dependency submission" must be
+#   DISABLED. Otherwise the managed run keeps executing in parallel with this
+#   workflow and continues to fail with the error above.
+#
+# Note on the wrapper: this project's Gradle wrapper lives under scripts/, not
+# at the repo root, so we let the action provision Gradle itself via
+# `gradle-version` rather than relying on a root `gradlew`.
+name: Dependency Submission
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    # Weekly refresh so the graph stays current even without a push.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    name: Submit Gradle dependency graph
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4.7.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v4
+        with:
+          # AGP 8.13.2 is incompatible with Gradle 9.6.0+ (which removed the
+          # InternalProblems internal API). 8.13 matches the repo wrapper and
+          # is the version the project actually configures/builds with.
+          gradle-version: '8.13'


### PR DESCRIPTION
## Problem

The **Automatic Dependency Submission (Gradle)** workflow has been failing on every run (e.g. runs 28284841763, 28283982723 on 2026-06-27). The real error:

```
FAILURE: Build failed with an exception.
* What went wrong:
An exception occurred applying plugin request [id: 'com.android.application']
   > Failed to create service '...AndroidProblemReporterProvider...'.
      > Could not create service of type InternalProblems using
        ProblemsBuildTreeServices.createInternalProblems().
```

## Root cause

This run is GitHub's **managed** "Automatic Dependency Submission" feature, which uses the **latest** Gradle — **9.6.0**. Gradle 9.6.0 removed the internal `InternalProblems` API that **Android Gradle Plugin 8.13.2** (this project) relies on. Gradle's own log even says *"use Gradle 9.5"*. The repo's wrapper targets **8.13** and the normal release build (`./scripts/gradlew`) passes precisely because it is **not** on 9.6.

The two failures are linked to the Dependabot `security_update_dependency_not_found` errors too: a broken submission means a stale/incomplete dependency graph.

## Fix

Add an explicit `.github/workflows/dependency-submission.yml` that provisions **Gradle 8.13** (compatible with AGP 8.13.2) via `gradle/actions/dependency-submission@v4`, JDK 17 / temurin (matching `release.yml`). Configuration succeeds because dependency resolution is not a `release` task — it does not trip the `VRHUB_UPDATE_SECRET` guard, and the CI signing path falls back to debug at configuration time without failing.

> Note: the project's wrapper lives under `scripts/` (no root `gradlew`), so the action provisions Gradle itself via `gradle-version` rather than using a root wrapper.

## ⚠️ One-time manual action required

Disable the **managed** feature so it stops running (and failing) in parallel:
**Settings → Code security → "Automatic dependency submission" → Disable.**

## Verification

- Workflow YAML parses cleanly.
- Compatibility reasoning is grounded in Gradle's own error message ("use Gradle 9.5"); 8.13 is the wrapper-pinned, AGP-compatible version.
- Full validation happens on the first run of this workflow once merged (and the managed feature disabled).