### PR TITLE
fix(stats): normalize tier in StatsCollectionWorker

### DIFF
--- a/app/src/main/java/com/vrhub/worker/StatsCollectionWorker.kt
+++ b/app/src/main/java/com/vrhub/worker/StatsCollectionWorker.kt
@@ -61,13 +61,21 @@ class StatsCollectionWorker(
             Log.d(TAG, "Stats collection work cancelled")
         }
 
-        private suspend fun resolveTier(): String? {
+        private suspend fun resolveTier(): String {
             return try {
                 val response = NetworkModule.statsApiService.getUserTier("anonymous")
-                if (response.isSuccessful) response.body()?.tier else null
+                if (response.isSuccessful) {
+                    // Normalize through the shared helper so unknown/empty tiers
+                    // fall back to "standard" instead of being sent raw to the
+                    // server (mirrors StatsCollectDebounceWorker / MainRepository).
+                    com.vrhub.network.resolveTier(response.body()?.tier)
+                } else {
+                    Log.w(TAG, "resolveTier: server returned ${response.code()}, defaulting")
+                    "standard"
+                }
             } catch (e: Exception) {
                 Log.w(TAG, "resolveTier: failed", e)
-                null
+                "standard"
             }
         }
     }
@@ -110,7 +118,7 @@ class StatsCollectionWorker(
             }
 
             // Resolve real user tier (same pattern as MainRepository.maybeCollectStats)
-            val tier = resolveTier() ?: "standard"
+            val tier = resolveTier()
             statsCollector.collectStats(null, installedGames, tier)
 
             Log.d(TAG, "doWork: stats collection completed")


### PR DESCRIPTION
## Problem

`StatsCollectionWorker.resolveTier()` returned the **raw** `tier` string from `getUserTier(...)` (or `null`):

```kotlin
if (response.isSuccessful) response.body()?.tier else null
```

Every other caller (`StatsCollectDebounceWorker`, `MainRepository`) runs the value through `network.resolveTier(tier: String?)`, which clamps unknown/blank tiers to `"standard"` (the server only recognizes `standard`/`supporter`/`lucky`). So if the server ever returns an unexpected tier (e.g. `"premium"`), this worker forwarded it verbatim in the `stats/collect` payload, where it may be rejected or miscounted.

## Fix

Route `StatsCollectionWorker` through the shared `network.resolveTier()` helper (and return `"standard"` on non-success / exception), exactly like `StatsCollectDebounceWorker`. The redundant `?: "standard"` at the call site is removed since the function is now non-nullable.

## Verification

- Logic mirrors the existing, tested `StatsCollectDebounceWorker.resolveTier()`.
- No signature change visible outside the companion object.