### PR TITLE
fix(catalog): avoid SQLite variable limit when pruning stale games

### DIFF
--- a/app/src/main/java/com/vrhub/data/GameDao.kt
+++ b/app/src/main/java/com/vrhub/data/GameDao.kt
@@ -52,6 +52,22 @@ interface GameDao {
     @Query("SELECT COUNT(*) FROM games")
     suspend fun getCount(): Int
 
-    @Query("DELETE FROM games WHERE releaseName NOT IN (:releaseNames)")
-    suspend fun deleteAbsent(releaseNames: List<String>)
+    /**
+     * Returns every release name currently in the catalog. Used to compute,
+     * in code, the set of stale games to delete — see deleteByReleaseNames.
+     */
+    @Query("SELECT releaseName FROM games")
+    suspend fun getAllReleaseNames(): List<String>
+
+    /**
+     * Deletes the given games by release name.
+     *
+     * Callers MUST chunk [releaseNames] to stay under SQLITE_MAX_VARIABLE_NUMBER
+     * (999 on Android < 12). This intentionally replaces the previous
+     * `DELETE ... WHERE releaseName NOT IN (:all)` query, which bound one
+     * variable per catalog entry and crashed with "too many SQL variables"
+     * once the catalog exceeded 999 games.
+     */
+    @Query("DELETE FROM games WHERE releaseName IN (:releaseNames)")
+    suspend fun deleteByReleaseNames(releaseNames: List<String>)
 }

--- a/app/src/main/java/com/vrhub/data/MainRepository.kt
+++ b/app/src/main/java/com/vrhub/data/MainRepository.kt
@@ -301,8 +301,14 @@ class MainRepository(
                                     // Guard: skip deletion when the new list is empty to avoid
                                     // wiping the entire local DB on a transient server error.
                                     if (newList.isNotEmpty()) {
-                                        val currentReleaseNames = newList.map { it.releaseName }
-                                        gameDao.deleteAbsent(currentReleaseNames)
+                                        // Compute the stale set in code and delete it in IN(...)
+                                        // chunks rather than issuing a single NOT IN(:all) query.
+                                        // The catalog exceeds 999 entries, which would blow past
+                                        // SQLITE_MAX_VARIABLE_NUMBER (999 on Android < 12) and
+                                        // crash the whole sync with "too many SQL variables".
+                                        val keep = newList.mapTo(HashSet()) { it.releaseName }
+                                        val toDelete = gameDao.getAllReleaseNames().filter { it !in keep }
+                                        toDelete.chunked(500).forEach { gameDao.deleteByReleaseNames(it) }
                                     }
                                     // 95% progress: DB insertion done, finalizing metadata.
                                     onProgress(0.95f)


### PR DESCRIPTION
## Problem

When a catalog sync completes, `syncCatalog` deletes games that are no longer on the server via:

```kotlin
@Query("DELETE FROM games WHERE releaseName NOT IN (:releaseNames)")
suspend fun deleteAbsent(releaseNames: List<String>)
```

Room expands this to `NOT IN (?, ?, … one per game …)`. SQLite caps host variables at **`SQLITE_MAX_VARIABLE_NUMBER` = 999** on Android < 12 (SQLite < 3.32). The VRHub catalog has well over 999 entries, so on Quest 1 / older Quest 2 firmware the statement throws:

```
android.database.sqlite.SQLiteException: too many SQL variables
```

That exception is caught by `syncCatalog`'s outer handler, which calls `onProgress(-1f)` and rethrows — the **entire sync fails** and the local DB is never pruned of removed games.

## Fix

Compute the stale set in Kotlin and delete it in `IN (:chunk)` batches of 500:

```kotlin
val keep = newList.mapTo(HashSet()) { it.releaseName }
val toDelete = gameDao.getAllReleaseNames().filter { it !in keep }
toDelete.chunked(500).forEach { gameDao.deleteByReleaseNames(it) }
```

`deleteAbsent` (NOT IN) is replaced by `getAllReleaseNames` + `deleteByReleaseNames` (IN). Chunking a `NOT IN` would be incorrect (each chunk would delete everything not in *that* chunk), so the deletion set is derived in code and applied additively, keeping each query well under the 999-variable ceiling.

## Verification

- `deleteAbsent` had a single caller (`MainRepository.syncCatalog`); no remaining references after the change.
- Pure Room/Kotlin idioms; no schema change (no migration needed).