### PR TITLE
fix(worker): handle rename + empty-extraction failures in CatalogUpdateWorker

### DIFF
--- a/app/src/main/java/com/vrhub/worker/CatalogUpdateWorker.kt
+++ b/app/src/main/java/com/vrhub/worker/CatalogUpdateWorker.kt
@@ -93,7 +93,14 @@ class CatalogUpdateWorker(
             
                                 val sharedCacheFile = CatalogUtils.getCatalogMetaFile(applicationContext)
             
-                                privateTempFile.renameTo(sharedCacheFile)
+                                if (!privateTempFile.renameTo(sharedCacheFile)) {
+                                    // If the move fails, extractGameList below would read a
+                                    // stale (or missing) shared cache file and silently
+                                    // mis-report the update. Bail out and let WorkManager retry.
+                                    Log.e(TAG, "Failed to move downloaded meta file into shared cache")
+                                    privateTempFile.delete()
+                                    return@withContext Result.retry()
+                                }
             
             
             
@@ -139,7 +146,11 @@ class CatalogUpdateWorker(
             
                                 } else {
             
+                                    // Extraction yielded nothing: the notification metadata was
+                                    // NOT saved, so retry rather than reporting success (which
+                                    // would leave the update banner stuck until the next change).
                                     Log.e(TAG, "Failed to extract game list content")
+                                    return@withContext Result.retry()
             
                                 }
             


### PR DESCRIPTION
## Problem

`CatalogUpdateWorker` has two silent-failure paths after the background download:

**1. Unchecked `renameTo`.**
```kotlin
privateTempFile.renameTo(sharedCacheFile)   // boolean result ignored
val gameListContent = extractGameList(sharedCacheFile, password)
```
If the move fails, `extractGameList` reads a **stale or missing** shared cache file. The worker then either mis-reports the update count or hits the empty-content branch — yet still finishes as `Result.success()`.

**2. Empty extraction → success.**
When `extractGameList` returns `""`, the `else` branch only logged the error and fell through to `Result.success()`. But `notified_meta_` was never saved, so the catalog-update banner can stay stuck until the next server change, with no retry.

## Fix

- Check `renameTo`'s return value; on failure delete the temp file and `Result.retry()`.
- In the empty-extraction branch, `Result.retry()` so WorkManager retries with its backoff policy.

Both early returns are non-local returns through the inline `Mutex.withLock`, targeting the `doWork` `withContext` lambda (the worker already uses `return@withContext Result.success()` elsewhere).

## Verification

- Control flow reviewed: the normal path still reaches `Result.success()`; the new returns bypass the outer `try/catch` cleanly (they are returns, not exceptions).
- No API/signature changes.