### PR TITLE
ci: fix PR Validation summary + bump emulator runner

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -159,7 +159,12 @@ jobs:
         uses: ./.github/actions/gradle-cache
       - name: Run Instrumented Tests
         id: run-instr
-        uses: reactivecircus/android-emulator-runner@v2.30.1
+        # Bumped from v2.30.1: on the current ubuntu-latest runner image the
+        # old action failed AVD creation with "cannot create
+        # .../test.avd/config.ini: Directory nonexistent" (the .avd dir was
+        # never created), so every instrumented run aborted before booting
+        # the emulator. v2.37.x ships the AVD-path fixes for newer images.
+        uses: reactivecircus/android-emulator-runner@v2.37.0
         with:
           api-level: 29
           target: default
@@ -315,7 +320,16 @@ jobs:
         shell: bash
         run: |
           overall_success="${{ needs.lint.result == 'success' && needs.unit-tests.result == 'success' && needs.build.result == 'success' }}"
-          echo "### PR Validation: ${overall_success == 'true' && '✅ PASS' || '❌ FAIL'}" >> $GITHUB_STEP_SUMMARY
+          # NOTE: pick the label in bash. The previous version inlined a
+          # GitHub Actions expression (`&&`/`||`) inside a bash `${...}`
+          # expansion, which bash parsed as a parameter substitution and
+          # rejected with "bad substitution", failing this step every run.
+          if [ "$overall_success" = "true" ]; then
+            status="✅ PASS"
+          else
+            status="❌ FAIL"
+          fi
+          echo "### PR Validation: $status" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "[View Full PR Feedback and Artifacts](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -157,6 +157,16 @@ jobs:
           distribution: 'temurin'
       - name: Gradle Cache
         uses: ./.github/actions/gradle-cache
+      - name: Enable KVM
+        # Without this the GitHub-hosted runner can't access /dev/kvm, so the
+        # emulator action falls back to "-accel off" (software emulation).
+        # An API-29 x86_64 image then boots too slowly to finish before the
+        # timeout — the device stays "offline" and the run fails. Granting the
+        # runner user access to /dev/kvm restores hardware acceleration.
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Run Instrumented Tests
         id: run-instr
         # Bumped from v2.30.1: on the current ubuntu-latest runner image the


### PR DESCRIPTION
## Contexte
Deux jobs de `pr-validation.yml` échouaient sur **toutes** les PRs récentes, indépendamment du code soumis.

## Corrections

### 1. `Consolidation & Feedback` → étape `Build summary` (déterministe)
La ligne inlinait une expression GitHub Actions (`&&` / `||`) à l'intérieur d'une expansion bash `${...}` :
```
echo "### PR Validation: ${overall_success == 'true' && '✅ PASS' || '❌ FAIL'}"
```
Bash l'interprétait comme une substitution de paramètre et échouait avec `bad substitution`, faisant rater le step à chaque run. Remplacé par un `if`/`else` bash classique.

### 2. `Instrumented Tests` → bump `android-emulator-runner` v2.30.1 → v2.37.0
Sur l'image `ubuntu-latest` actuelle, l'ancienne action échouait la création de l'AVD avec :
```
cannot create /home/runner/.android/avd/test.avd/config.ini: Directory nonexistent
```
(le dossier `.avd` n'était jamais créé → l'émulateur ne démarrait pas). v2.37.x embarque les correctifs de chemin AVD pour les images de runner récentes.

## Validation
Le CI de cette PR exécute `pr-validation.yml` : il confirme directement les deux fixes (la step `Build summary` doit passer, et `Instrumented Tests` doit booter l'émulateur).