### PR TITLE
fix: stop game list reshuffling while scrolling under Size sort (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### Fixed
+- **Game list reshuffling while scrolling (#15):** Under the **Size** sort, the catalog list
+  kept reordering as you scrolled because game sizes are fetched lazily for the games coming
+  into view, and each newly resolved size re-triggered a full re-sort that moved items around
+  under the user. The sorted order is now frozen against transient updates (lazily fetched
+  sizes, install/queue progress) and is only recomputed when the structural sort inputs change
+  (sort mode, search query, filter, or the set of games shown). Per-item content such as the
+  size label still updates live; only the ordering is held stable.
+
 ## [4.1.5] - 2026-06-27
 
 ### Added

--- a/app/src/main/java/com/vrhub/ui/MainViewModel.kt
+++ b/app/src/main/java/com/vrhub/ui/MainViewModel.kt
@@ -924,6 +924,22 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         counts
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyMap())
 
+    /**
+     * Caches the last sorted order of release names so transient updates that do not
+     * affect ordering (e.g. sizes fetched lazily while scrolling, install/queue progress)
+     * do not reshuffle the visible list. The order is only recomputed when the structural
+     * sort inputs change: the sort mode, search query, filter, or the set of games shown.
+     * Fixes #15 (list "continually changing/updating" while scrolling under Size sort).
+     */
+    private data class SortOrderCache(
+        val query: String,
+        val filter: FilterStatus,
+        val sort: SortMode,
+        val members: Set<String>,
+        val order: List<String>
+    )
+    private var sortOrderCache: SortOrderCache? = null
+
     @Suppress("UNCHECKED_CAST")
     val games: StateFlow<List<GameItemState>> = combine(
         _allGames,
@@ -975,14 +991,29 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             matchesQuery && matchesFilter
         }
 
-        val sortedList = when (sort) {
-            SortMode.NAME_ASC -> filteredList.sortedWith(compareBy<GameData> {
-                getAlphabetSortPriority(getAlphabetGroupChar(it.gameName))
-            }.thenBy(String.CASE_INSENSITIVE_ORDER) { it.gameName })
-            SortMode.NAME_DESC -> filteredList.sortedByDescending { it.gameName }
-            SortMode.LAST_UPDATED -> filteredList.sortedByDescending { it.lastUpdated }
-            SortMode.SIZE -> filteredList.sortedByDescending { it.sizeBytes ?: 0L }
-            SortMode.POPULARITY -> filteredList.sortedByDescending { it.popularity }
+        // Freeze the order against transient updates (e.g. sizes fetched lazily while
+        // scrolling) by reusing the cached order whenever the structural sort inputs are
+        // unchanged. Per-item content below still refreshes from the current data. (#15)
+        val members = filteredList.mapTo(HashSet()) { it.releaseName }
+        val cache = sortOrderCache
+        val sortedList = if (
+            cache != null && cache.query == query && cache.filter == filter &&
+            cache.sort == sort && cache.members == members
+        ) {
+            val byReleaseName = filteredList.associateBy { it.releaseName }
+            cache.order.mapNotNull { byReleaseName[it] }
+        } else {
+            val freshSorted = when (sort) {
+                SortMode.NAME_ASC -> filteredList.sortedWith(compareBy<GameData> {
+                    getAlphabetSortPriority(getAlphabetGroupChar(it.gameName))
+                }.thenBy(String.CASE_INSENSITIVE_ORDER) { it.gameName })
+                SortMode.NAME_DESC -> filteredList.sortedByDescending { it.gameName }
+                SortMode.LAST_UPDATED -> filteredList.sortedByDescending { it.lastUpdated }
+                SortMode.SIZE -> filteredList.sortedByDescending { it.sizeBytes ?: 0L }
+                SortMode.POPULARITY -> filteredList.sortedByDescending { it.popularity }
+            }
+            sortOrderCache = SortOrderCache(query, filter, sort, members, freshSorted.map { it.releaseName })
+            freshSorted
         }
 
         sortedList.map { game ->


### PR DESCRIPTION
Fixes #15

## Root cause

The `games` `StateFlow` in `MainViewModel` re-runs its `when (sort)` sort on **every** emission of its upstream flows, including `_allGames` and `installQueue`.

`startMetadataFetchLoop()` fetches each game's `sizeBytes` **lazily**, prioritising the items currently in view (`_visibleIndices`, which changes as you scroll). Each fetched size writes back to the DB (`gameDao.updateSize`), `_allGames` re-emits, and the list is re-sorted.

Under **Size** sort this is visible: games whose size hasn't loaded yet have `sizeBytes == null`, coalesced to `0L`, so they sit at the bottom; as you scroll, each newly resolved size makes its item jump to its true position. Combined with `animateItemPlacement()`, the list appears to "continually change/update while scrolling" — exactly the report. (Name / Last-updated / Popularity come from the catalog and are stable, so they never thrash.)

## Fix

Freeze the sorted **order** against transient updates. The order of release names is cached and only recomputed when the *structural* sort inputs change: sort mode, search query, filter, or the set of games shown. Lazily fetched sizes and install/queue progress reuse the cached order.

Per-item content (size label, install/queue/favorite status) is still rebuilt from the current data on every emission, so only the ordering is held stable — nothing goes stale visually except the position, which is the desired behaviour.

Scope is limited to the `games` combine in `MainViewModel.kt`; `LazyColumn`/grid keys were already stable (`it.releaseName`).

## Verification

- `scripts/gradlew.bat compileDevDebugKotlin` — **BUILD SUCCESSFUL** (only pre-existing warnings)
- `scripts/gradlew.bat testDevDebugUnitTest` — **BUILD SUCCESSFUL**
- Instrumented/emulator tests not run (not required).

## Changelog

Added an `Unreleased` → `Fixed` entry.