### PR TITLE
feat(catalog): sortable Release Name + sort direction & inline sorted value (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+### Added
+- **Sortable Release Name + sort direction (issue #14):** The catalog sort menu now offers a
+  **Release Name** option and supports both ascending and descending order for every field.
+  Re-tapping the active field flips its direction (Rookie-style toggle) while a ▲/▼ arrow in the
+  menu shows which way the list is currently sorted. Each field starts in its natural direction
+  (A→Z for names, newest/largest/most-popular first otherwise).
+- **Sorted value visible inline (issue #14):** The active sort key is now shown directly on each
+  game row — Last Updated date, popularity, or release name appear next to the version/size line
+  in the accent colour, so the sorted field is visible without expanding the card.
+
 ### Fixed
 - **Game list reshuffling while scrolling (#15):** Under the **Size** sort, the catalog list
   kept reordering as you scrolled because game sizes are fetched lazily for the games coming

--- a/app/src/main/java/com/vrhub/MainActivity.kt
+++ b/app/src/main/java/com/vrhub/MainActivity.kt
@@ -147,6 +147,7 @@ fun MainScreen(viewModel: MainViewModel = viewModel()) {
     val searchQuery by viewModel.searchQuery.collectAsState()
     val selectedFilter by viewModel.selectedFilter.collectAsState()
     val sortMode by viewModel.sortMode.collectAsState()
+    val sortAscending by viewModel.sortAscending.collectAsState()
     val filterCounts by viewModel.filterCounts.collectAsState()
     val missingPermissions by viewModel.missingPermissions.collectAsState()
     val alphabetInfo by viewModel.alphabetInfo.collectAsState()
@@ -652,6 +653,7 @@ fun MainScreen(viewModel: MainViewModel = viewModel()) {
                                     selectedFilter = selectedFilter,
                                     onFilterChange = { viewModel.setFilter(it) },
                                     sortMode = sortMode,
+                                    sortAscending = sortAscending,
                                     onSortChange = { viewModel.setSortMode(it) },
                                     filterCounts = filterCounts,
                                     onSettingsClick = { showSettingsDialog = true },
@@ -699,7 +701,7 @@ fun MainScreen(viewModel: MainViewModel = viewModel()) {
                                     }
 
                                     Row(modifier = Modifier.weight(1f)) {
-                                        if (games.isNotEmpty() && searchQuery.isEmpty() && selectedFilter == FilterStatus.ALL && sortMode == SortMode.NAME_ASC) {
+                                        if (games.isNotEmpty() && searchQuery.isEmpty() && selectedFilter == FilterStatus.ALL && sortMode == SortMode.NAME && sortAscending) {
                                         AlphabetIndexer(
                                             alphabetInfo = alphabetInfo,
                                             onLetterClick = { index ->
@@ -741,6 +743,7 @@ fun MainScreen(viewModel: MainViewModel = viewModel()) {
                                                     onResumeClick = { viewModel.resumeInstall(game.releaseName) },
                                                     onToggleFavorite = { viewModel.toggleFavorite(game.releaseName, it) },
                                                     isGridItem = true,
+                                                    sortMode = sortMode,
                                                     permissionsMissing = missingPermissions?.isNotEmpty() == true,
                                                     modifier = Modifier.animateItemPlacement()
                                                 )
@@ -761,6 +764,7 @@ fun MainScreen(viewModel: MainViewModel = viewModel()) {
                                                     onDeleteDownloadClick = { gameToDelete = game },
                                                     onResumeClick = { viewModel.resumeInstall(game.releaseName) },
                                                     onToggleFavorite = { viewModel.toggleFavorite(game.releaseName, it) },
+                                                    sortMode = sortMode,
                                                     permissionsMissing = missingPermissions?.isNotEmpty() == true,
                                                     modifier = Modifier.animateItemPlacement()
                                                 )
@@ -1217,6 +1221,7 @@ fun CustomTopBar(
     selectedFilter: FilterStatus,
     onFilterChange: (FilterStatus) -> Unit,
     sortMode: SortMode,
+    sortAscending: Boolean,
     onSortChange: (SortMode) -> Unit,
     filterCounts: Map<FilterStatus, Int>,
     onSettingsClick: () -> Unit,
@@ -1297,26 +1302,33 @@ fun CustomTopBar(
                         expanded = showSortMenu,
                         onDismissRequest = { showSortMenu = false }
                     ) {
-                        DropdownMenuItem(
-                            text = { Text("Name (A-Z)", color = Color.White) },
-                            onClick = { onSortChange(SortMode.NAME_ASC); showSortMenu = false },
-                            leadingIcon = { if (sortMode == SortMode.NAME_ASC) Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.secondary) }
-                        )
-                        DropdownMenuItem(
-                            text = { Text("Last Updated", color = Color.White) },
-                            onClick = { onSortChange(SortMode.LAST_UPDATED); showSortMenu = false },
-                            leadingIcon = { if (sortMode == SortMode.LAST_UPDATED) Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.secondary) }
-                        )
-                        DropdownMenuItem(
-                            text = { Text("Size", color = Color.White) },
-                            onClick = { onSortChange(SortMode.SIZE); showSortMenu = false },
-                            leadingIcon = { if (sortMode == SortMode.SIZE) Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.secondary) }
-                        )
-                        DropdownMenuItem(
-                            text = { Text("Popularity", color = Color.White) },
-                            onClick = { onSortChange(SortMode.POPULARITY); showSortMenu = false },
-                            leadingIcon = { if (sortMode == SortMode.POPULARITY) Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.secondary) }
-                        )
+                        // Tapping the active field flips its direction (and keeps the menu open
+                        // so the arrow change is visible); tapping another field switches to it.
+                        @Composable
+                        fun sortItem(label: String, mode: SortMode) {
+                            val selected = sortMode == mode
+                            DropdownMenuItem(
+                                text = { Text(label, color = Color.White) },
+                                onClick = {
+                                    onSortChange(mode)
+                                    if (!selected) showSortMenu = false
+                                },
+                                leadingIcon = { if (selected) Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.secondary) },
+                                trailingIcon = {
+                                    if (selected) Icon(
+                                        imageVector = if (sortAscending) Icons.Default.ArrowUpward else Icons.Default.ArrowDownward,
+                                        contentDescription = if (sortAscending) "Ascending" else "Descending",
+                                        tint = MaterialTheme.colorScheme.secondary,
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                }
+                            )
+                        }
+                        sortItem("Name", SortMode.NAME)
+                        sortItem("Release Name", SortMode.RELEASE_NAME)
+                        sortItem("Last Updated", SortMode.LAST_UPDATED)
+                        sortItem("Size", SortMode.SIZE)
+                        sortItem("Popularity", SortMode.POPULARITY)
                     }
                 }
 

--- a/app/src/main/java/com/vrhub/ui/GameListItem.kt
+++ b/app/src/main/java/com/vrhub/ui/GameListItem.kt
@@ -53,6 +53,7 @@ fun GameListItem(
     onResumeClick: () -> Unit = {},
     onToggleFavorite: (Boolean) -> Unit = {},
     isGridItem: Boolean = false,
+    sortMode: SortMode = SortMode.NAME,
     permissionsMissing: Boolean = false,
     modifier: Modifier = Modifier
 ) {
@@ -208,6 +209,28 @@ fun GameListItem(
                                 style = MaterialTheme.typography.bodySmall,
                                 color = Color.Gray,
                                 modifier = Modifier.padding(start = 4.dp),
+                                fontSize = 11.sp
+                            )
+                        }
+
+                        // Surface the active sort field inline so the value is visible without
+                        // expanding the card (issue #14 / Schintilla's request). Size and name are
+                        // already shown elsewhere, so only the remaining fields need it; highlighted
+                        // in the accent colour to signal it's the current sort key.
+                        val sortedFieldText: String? = when (sortMode) {
+                            SortMode.LAST_UPDATED -> formatDate(game.lastUpdated)
+                            SortMode.POPULARITY -> if (game.popularity > 0) "⭐ ${game.popularity}" else null
+                            SortMode.RELEASE_NAME -> game.releaseName
+                            else -> null
+                        }
+                        if (sortedFieldText != null) {
+                            Text(
+                                text = " • $sortedFieldText",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.secondary,
+                                modifier = Modifier.padding(start = 4.dp).weight(1f, fill = false),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                                 fontSize = 11.sp
                             )
                         }

--- a/app/src/main/java/com/vrhub/ui/MainViewModel.kt
+++ b/app/src/main/java/com/vrhub/ui/MainViewModel.kt
@@ -100,9 +100,14 @@ enum class FilterStatus {
     LOCAL_INSTALLS
 }
 
+/**
+ * Sort fields for the catalog. Direction (ascending/descending) is tracked separately in
+ * [MainViewModel.sortAscending] so any field can be sorted either way — see issue #14 and
+ * Schintilla's request to surface which way the list is sorted.
+ */
 enum class SortMode {
-    NAME_ASC,
-    NAME_DESC,
+    NAME,
+    RELEASE_NAME,
     LAST_UPDATED,
     SIZE,
     POPULARITY
@@ -418,8 +423,11 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _selectedFilter = MutableStateFlow(FilterStatus.ALL)
     val selectedFilter: StateFlow<FilterStatus> = _selectedFilter
 
-    private val _sortMode = MutableStateFlow(SortMode.NAME_ASC)
+    private val _sortMode = MutableStateFlow(SortMode.NAME)
     val sortMode: StateFlow<SortMode> = _sortMode
+
+    private val _sortAscending = MutableStateFlow(true)
+    val sortAscending: StateFlow<Boolean> = _sortAscending
 
     private val _events = MutableSharedFlow<MainEvent>()
     val events = _events.asSharedFlow()
@@ -935,6 +943,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val query: String,
         val filter: FilterStatus,
         val sort: SortMode,
+        val ascending: Boolean,
         val members: Set<String>,
         val order: List<String>
     )
@@ -948,7 +957,8 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         _downloadedReleases,
         _selectedFilter,
         _sortMode,
-        installQueue
+        installQueue,
+        _sortAscending
     ) { args ->
         val list = args[0] as List<GameData>
         val query = args[1] as String
@@ -957,6 +967,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val filter = args[4] as FilterStatus
         val sort = args[5] as SortMode
         val queue = args[6] as List<InstallTaskState>
+        val ascending = args[7] as Boolean
 
         val firstInQueue = queue.firstOrNull()?.releaseName
         val lastSync = prefs.getLong("last_catalog_sync_time", 0L)
@@ -994,25 +1005,28 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         // Freeze the order against transient updates (e.g. sizes fetched lazily while
         // scrolling) by reusing the cached order whenever the structural sort inputs are
         // unchanged. Per-item content below still refreshes from the current data. (#15)
+        // The sort direction (#14) is part of the structural key so flipping asc/desc
+        // recomputes the order.
         val members = filteredList.mapTo(HashSet()) { it.releaseName }
         val cache = sortOrderCache
         val sortedList = if (
             cache != null && cache.query == query && cache.filter == filter &&
-            cache.sort == sort && cache.members == members
+            cache.sort == sort && cache.ascending == ascending && cache.members == members
         ) {
             val byReleaseName = filteredList.associateBy { it.releaseName }
             cache.order.mapNotNull { byReleaseName[it] }
         } else {
-            val freshSorted = when (sort) {
-                SortMode.NAME_ASC -> filteredList.sortedWith(compareBy<GameData> {
+            val comparator: Comparator<GameData> = when (sort) {
+                SortMode.NAME -> compareBy<GameData> {
                     getAlphabetSortPriority(getAlphabetGroupChar(it.gameName))
-                }.thenBy(String.CASE_INSENSITIVE_ORDER) { it.gameName })
-                SortMode.NAME_DESC -> filteredList.sortedByDescending { it.gameName }
-                SortMode.LAST_UPDATED -> filteredList.sortedByDescending { it.lastUpdated }
-                SortMode.SIZE -> filteredList.sortedByDescending { it.sizeBytes ?: 0L }
-                SortMode.POPULARITY -> filteredList.sortedByDescending { it.popularity }
+                }.thenBy(String.CASE_INSENSITIVE_ORDER) { it.gameName }
+                SortMode.RELEASE_NAME -> compareBy(String.CASE_INSENSITIVE_ORDER) { it.releaseName }
+                SortMode.LAST_UPDATED -> compareBy { it.lastUpdated }
+                SortMode.SIZE -> compareBy { it.sizeBytes ?: 0L }
+                SortMode.POPULARITY -> compareBy { it.popularity }
             }
-            sortOrderCache = SortOrderCache(query, filter, sort, members, freshSorted.map { it.releaseName })
+            val freshSorted = filteredList.sortedWith(if (ascending) comparator else comparator.reversed())
+            sortOrderCache = SortOrderCache(query, filter, sort, ascending, members, freshSorted.map { it.releaseName })
             freshSorted
         }
 
@@ -2570,9 +2584,24 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         priorityUpdateChannel.trySend(Unit)
     }
 
+    /**
+     * Selects a sort field. Re-selecting the active field flips the direction (Rookie-style
+     * toggle); selecting a new field resets it to that field's natural default direction
+     * (A→Z for names, newest/largest/most-popular first otherwise).
+     */
     fun setSortMode(mode: SortMode) {
-        _sortMode.value = mode
+        if (_sortMode.value == mode) {
+            _sortAscending.value = !_sortAscending.value
+        } else {
+            _sortMode.value = mode
+            _sortAscending.value = defaultSortAscending(mode)
+        }
         priorityUpdateChannel.trySend(Unit)
+    }
+
+    private fun defaultSortAscending(mode: SortMode): Boolean = when (mode) {
+        SortMode.NAME, SortMode.RELEASE_NAME -> true
+        SortMode.LAST_UPDATED, SortMode.SIZE, SortMode.POPULARITY -> false
     }
 
     /**


### PR DESCRIPTION
## Summary

Completes **issue #14** (sortable columns à la Rookie) and Schintilla's follow-up comment
about *seeing which way the list is sorted and the sorted field without expanding the card*.

Most of #14 was **already implemented** on `main`; this PR fills the remaining gaps.

### Already present (no change needed)
- Sort by **Last Updated** (newest first), **Size**, **Popularity**.
- **New** tab/filter showing games added since the last catalog upload (`FilterStatus.NEW`,
  driven by `last_catalog_sync_time`), with a count chip.
- Release Name, Last Updated and Popularity shown in the expanded card.

### Added in this PR
- **Sort by Release Name** — new option in the sort menu.
- **Sort direction (asc/desc) for every field** — `SortMode` is now a field-only enum with a
  separate `sortAscending` flag. Re-tapping the active field flips its direction (Rookie-style),
  selecting a new field resets to its natural default (A→Z for names; newest/largest/most-popular
  first otherwise).
- **Direction indicator** — a ▲/▼ arrow next to the active field in the sort menu shows the
  current direction (the menu stays open while toggling so the change is visible).
- **Sorted value visible inline** — each game row now shows the active sort key (Last Updated
  date / popularity / release name) next to the version·size line, in the accent colour, without
  needing to expand the card. (Size was already always shown.)

## Files
- `app/src/main/java/com/vrhub/ui/MainViewModel.kt` — `SortMode` enum, `sortAscending` state,
  comparator-based sort with direction, toggle logic in `setSortMode`.
- `app/src/main/java/com/vrhub/MainActivity.kt` — collect/pass `sortAscending`, Release Name menu
  item + direction arrow, alphabet-indexer guard, pass `sortMode` to rows.
- `app/src/main/java/com/vrhub/ui/GameListItem.kt` — inline sorted-field display.
- `CHANGELOG.md` — entry under Unreleased.

## Testing
- `./scripts/gradlew compileDevDebugKotlin` — **BUILD SUCCESSFUL** (pre-existing warnings only).
- `./scripts/gradlew testDevDebugUnitTest` — **BUILD SUCCESSFUL**, all unit tests pass.
- Instrumented/emulator tests not run (not required).

Closes #14
