### PR TITLE
ci(test): isolate instrumented tests with AndroidX Test Orchestrator (#57)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -114,6 +114,17 @@ android {
         }
     }
 
+    testOptions {
+        // ANDROIDX_TEST_ORCHESTRATOR runs every instrumented test in its own
+        // instrumentation process, so a single hung or crashing test no longer
+        // freezes the whole connectedAndroidTest run on the slow headless CI
+        // emulator (issue #57). clearPackageData is intentionally NOT enabled:
+        // a few tests rely on accumulated app state (permission cache, WorkManager)
+        // and wiping between tests would break them.
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
+        animationsDisabled = true
+    }
+
     // ================================================================================
     // SIGNING CONFIGURATION - Single source of truth for keystore availability
     // ================================================================================
@@ -340,6 +351,10 @@ dependencies {
     testImplementation("androidx.test.ext:junit:1.1.5")
     testImplementation("androidx.test:core:1.5.0")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test:runner:1.5.2")
+    // AndroidX Test Orchestrator: isolates each instrumented test in its own
+    // process so a hung/crashing test can't freeze the whole suite (issue #57).
+    androidTestUtil("androidx.test:orchestrator:1.4.2")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2023.10.01"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/app/src/androidTest/java/com/vrhub/worker/DownloadWorkerTest.kt
+++ b/app/src/androidTest/java/com/vrhub/worker/DownloadWorkerTest.kt
@@ -21,6 +21,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.Ignore
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
@@ -53,6 +54,31 @@ class DownloadWorkerTest {
 
         WorkManagerTestInitHelper.initializeTestWorkManager(context, config)
         workManager = WorkManager.getInstance(context)
+    }
+
+    /**
+     * Waits for a worker to leave the transient RUNNING state and settle.
+     *
+     * DownloadWorker is a CoroutineWorker, so its body runs on its own coroutine
+     * dispatcher — the test's SynchronousExecutor only drives WorkManager's task
+     * executor, not the worker body. Reading the state immediately after enqueue
+     * can therefore observe RUNNING. Under AndroidX Test Orchestrator each test
+     * gets a cold process, which makes that window wide enough to flake. Poll
+     * until the work finishes (SUCCEEDED/FAILED/CANCELLED) or, after having run,
+     * settles back to ENQUEUED for retry backoff.
+     */
+    private fun awaitWorkSettled(id: UUID, timeoutMs: Long = 15_000): WorkInfo {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        var sawRunning = false
+        var info = workManager.getWorkInfoById(id).get()
+        while (System.currentTimeMillis() < deadline) {
+            if (info.state == WorkInfo.State.RUNNING) sawRunning = true
+            if (info.state.isFinished) break
+            if (sawRunning && info.state == WorkInfo.State.ENQUEUED) break
+            Thread.sleep(50)
+            info = workManager.getWorkInfoById(id).get()
+        }
+        return info
     }
 
     @Test
@@ -254,7 +280,7 @@ class DownloadWorkerTest {
         testDriver?.setAllConstraintsMet(request.id)
 
         // Then: Work should fail due to missing release name
-        val workInfo = workManager.getWorkInfoById(request.id).get()
+        val workInfo = awaitWorkSettled(request.id)
         assertEquals(
             "Work should FAIL with missing release name",
             WorkInfo.State.FAILED,
@@ -290,7 +316,7 @@ class DownloadWorkerTest {
         testDriver?.setAllConstraintsMet(request.id)
 
         // Then: Work should fail (either immediately or after retries)
-        val workInfo = workManager.getWorkInfoById(request.id).get()
+        val workInfo = awaitWorkSettled(request.id)
         assertTrue(
             "Work should FAIL or RETRY with non-existent game",
             workInfo.state == WorkInfo.State.FAILED ||


### PR DESCRIPTION
## Summary

Robust infra fix for the recurring **Instrumented Tests hang** (#57). Quarantining one offender at a time was whack-a-mole — after `MigrationManagerTest` was quarantined, the suite still froze on `PermissionManagerInstrumentedTest` on a cold CI run (PR #55), while passing on PR #58. The hang is intermittent and stalls the single shared instrumentation process at test instantiation, so `timeout_msec` never fires and the job dies at the 25-minute timeout.

## Fix

Switch instrumented execution to **AndroidX Test Orchestrator** (`testOptions { execution = "ANDROIDX_TEST_ORCHESTRATOR" }` + `androidTestUtil("androidx.test:orchestrator")`). Each test runs in its own instrumentation process, so:
- a single hung/crashing test can no longer freeze the whole run, and
- the cold-per-test isolation removes the cross-test state contamination that made these hangs intermittent.

`clearPackageData` is intentionally **left off** — a few tests rely on accumulated app state (permission cache, WorkManager) and wiping between tests breaks them.

### Collateral: fixed a pre-existing race in DownloadWorkerTest

The orchestrator's cold-process-per-test exposed a latent race: `DownloadWorker` is a `CoroutineWorker` whose body runs on its own dispatcher (the test's `SynchronousExecutor` only drives WorkManager's task executor), so reading `WorkInfo` immediately after enqueue can observe `RUNNING`. Added `awaitWorkSettled()` to poll until the work finishes or settles into retry backoff — fixes `doWork_withMissingReleaseName_fails` and `doWork_withNonExistentGame_fails`.

## Verification

On an API-29 / x86_64 / Nexus 6 AVD (the CI config) under the orchestrator: **`tests=114 failures=0 skipped=17`, BUILD SUCCESSFUL**. (The orchestrator-exposed failures, unlike the CI-only hang, reproduce locally — so this was validated locally end-to-end.)

## Follow-up

`MigrationManagerTest` stays quarantined for now; with per-process isolation it may be safe to restore, but that needs a CI run to confirm (its hang doesn't reproduce locally). Tracked under #57.
